### PR TITLE
Replace jistype with is to avoid CoffeeScript compatibility issue

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,5 +1,5 @@
 var validator = require('validator')
-    , is = require('jistype')
+    , is = require('is')
 
     , extend = require('./extend')
     , sanitizers = [
@@ -123,7 +123,7 @@ function makeCheck(field, validationErrorFormatter, onValidationError){
             }
             ctx._validationErrors.push(error);
 
-            if (onValidationError && is.isFunction(onValidationError)) {
+            if (onValidationError && is.function(onValidationError)) {
                 onValidationError.call(ctx, msg);
             }
         };
@@ -169,9 +169,9 @@ function makeExtend(type){
 
     return function(name, fn){
         var objs = {};
-        if(is.isString(name) && is.isFunction(fn)){
+        if(is.string(name) && is.function(fn)){
             obj[name] = fn;
-        }else if(is.isObject(name)){
+        }else if(is.object(name)){
             objs = name;
         }
 
@@ -217,7 +217,7 @@ function koaValidator(options){
     options = options || {};
 
     if(options.validationErrorFormatter){
-        if(!is.isFunction(options.validationErrorFormatter)){
+        if(!is.function(options.validationErrorFormatter)){
             throw new Error('validationErrorFormatter must be a function');
         }else{
             validationErrorFormatter = options.validationErrorFormatter;
@@ -225,7 +225,7 @@ function koaValidator(options){
     }
 
     if(options.onValidationError){
-        if(!is.isFunction(options.onValidationError)){
+        if(!is.function(options.onValidationError)){
             throw new Error('onValidationError must be a function');
         }
         else{

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "supertest": "^0.13.0"
   },
   "dependencies": {
-    "jistype": "^0.1.0",
+    "is": "^3.0.1",
     "validator": "^3.17.0"
   },
   "directories": {


### PR DESCRIPTION
Because of CoffeeScript has compatibility issue with io.js, so should use [`is`](https://www.npmjs.com/package/is) to avoid it.

![screen shot 2015-03-02 at 5 34 19 pm](https://cloud.githubusercontent.com/assets/189559/6438454/0fd42726-c104-11e4-8a99-4fb793341f66.png)

Though I can reinstall `koa-validator` to force upgrade `coffee-script` to v1.9 to fix this issue, but I think the best way is do not use transpiler in libraries.
